### PR TITLE
Ardu pirate stable mode

### DIFF
--- a/Accel.h
+++ b/Accel.h
@@ -438,7 +438,7 @@ public:
     }
     
     // store accel value that represents 1g
-    accelOneG = getRaw[ZAXIS];
+    accelOneG = getRaw(ZAXIS);
     // replace with estimated Z axis 0g value
     accelZero[ZAXIS] = (accelZero[ROLL] + accelZero[PITCH]) / 2;
     


### PR DESCRIPTION
Hey

I have mesured Z value with the configurator for Oilpan and v1.8/v2.0 

That prevent accelOneG to be badly calibrated or calibrated with an accel not leveled. Have tested it and that give good result. May be value should be extracted from the spec but I believe that accelOneG should be hardcoded, in case of someone have an accel not leveled by is quad build!

up to you!
