### PR TITLE
Removed processAltitudeHold() from the X and + flight controls functions 

### DIFF
--- a/FlightControl.pde
+++ b/FlightControl.pde
@@ -280,7 +280,7 @@ void processFlightControlXMode(void) {
   processHeading();
 
   // ********************** Altitude Adjust **********************************
-  processAltitudeHold();
+  //processAltitudeHold();
 
   // ********************** Calculate Motor Commands *************************
   if (armed && safetyCheck) {
@@ -334,7 +334,7 @@ void processFlightControlPlusMode(void) {
   processHeading();
 
   // ********************** Altitude Adjust **********************************
-  processAltitudeHold();
+  //processAltitudeHold();
 
   // ********************** Calculate Motor Commands *************************
   if (armed && safetyCheck) {


### PR DESCRIPTION
Removed processAltitudeHold() from the X and + flight controls functions in FlightControl.pde
