### PR TITLE
Small bugfix on low pass filter value

### DIFF
--- a/Libraries/AQ_Gyroscope/Gyroscope_ITG3200.h
+++ b/Libraries/AQ_Gyroscope/Gyroscope_ITG3200.h
@@ -37,7 +37,7 @@ void initializeGyro() {
 	
   gyroScaleFactor = radians(1.0 / 14.375);  //  ITG3200 14.375 LSBs per °/sec
   updateRegisterI2C(gyroAddress, ITG3200_RESET_ADDRESS, ITG3200_RESET_VALUE); // send a reset to the device
-  updateRegisterI2C(gyroAddress, ITG3200_LOW_PASS_FILTER_ADDR, ITG3200_MEMORY_ADDRESS); // 10Hz low pass filter
+  updateRegisterI2C(gyroAddress, ITG3200_LOW_PASS_FILTER_ADDR, ITG3200_LOW_PASS_FILTER_VALUE); // 10Hz low pass filter
   updateRegisterI2C(gyroAddress, ITG3200_RESET_ADDRESS, ITG3200_OSCILLATOR_VALUE); // use internal oscillator 
 }
     


### PR DESCRIPTION
The low pass filter value is ok, but the wrong defined variable was used.
