### PR TITLE
Fix coordinates on OSD

### DIFF
--- a/Libraries/AQ_OSD/MAX7456_GPS.h
+++ b/Libraries/AQ_OSD/MAX7456_GPS.h
@@ -103,14 +103,14 @@ void displayGPS(long lat, long lon, long hlat, long hlon, long speed, long cours
 #ifdef USUnits
       speed=speed*36/1609; // convert from cm/s to mph 
       snprintf(buf,29,"%d:%c%02ld.%06ld%c%03ld.%06ld %3ld\031",numsats,
-               (lat>=0)?'N':'S',abs(lat)/10000000L,abs(lat)%10000000L/10,
-               (lon>=0)?'E':'W',abs(lon)/10000000L,abs(lon)%10000000L/10,
+               (lat>=0)?'N':'S',labs(lat)/10000000L,labs(lat)%10000000L/10,
+               (lon>=0)?'E':'W',labs(lon)/10000000L,labs(lon)%10000000L/10,
 	       speed);
 #else
       speed=speed*36/1000; // convert from cm/s to kmh 
       snprintf(buf,29,"%d:%c%02ld.%06ld%c%03ld.%06ld %3ld\030",numsats,
-               (lat>=0)?'N':'S',abs(lat)/10000000L,abs(lat)%10000000L/10,
-               (lon>=0)?'E':'W',abs(lon)/10000000L,abs(lon)%10000000L/10,
+               (lat>=0)?'N':'S',labs(lat)/10000000L,labs(lat)%10000000L/10,
+               (lon>=0)?'E':'W',labs(lon)/10000000L,labs(lon)%10000000L/10,
 	       speed);
 #endif
       writeChars(buf, 28, 0, GPS_ROW, GPS_COL);


### PR DESCRIPTION
This fixes the coordinate display on OSD. The problem is caused by AP_Common.h making "#undef abs" to remove the Aruino abs of "#define abs(x) ((x<0)?(-x):(x))".
