### PR TITLE
Minor updates, allow separate alt/pos hold

### DIFF
--- a/AeroQuad/FlightCommandProcessor.h
+++ b/AeroQuad/FlightCommandProcessor.h
@@ -97,11 +97,9 @@ void readPilotCommands() {
   // Check Mode switch for Acro or Stable
   if (receiverCommand[MODE] > 1500) {
     flightMode = ATTITUDE_FLIGHT_MODE;
-    digitalWrite(LED_Yellow, HIGH);
   }
   else {
     flightMode = RATE_FLIGHT_MODE;
-    digitalWrite(LED_Yellow, LOW);
   }
 
   
@@ -151,7 +149,7 @@ void readPilotCommands() {
 
       navigationState = ON;
     }
-    else if (receiverCommand[AUX1] < 1750) {  // Enter in position hold state
+    else if (receiverCommand[AUX1] < 1600) {  // Enter in position hold state
       
       if (isStorePositionNeeded) {
         
@@ -183,5 +181,3 @@ void readPilotCommands() {
 }
 
 #endif // _AQ_FLIGHT_COMMAND_READER_
-
-

--- a/AeroQuad/LedStatusProcessor.h
+++ b/AeroQuad/LedStatusProcessor.h
@@ -59,6 +59,16 @@ void processLedStatus() {
     }
   #endif  
 
+  //
+  // process mode light
+  //
+  if (flightMode == ATTITUDE_FLIGHT_MODE) {
+    digitalWrite(LED_Yellow, HIGH);
+  }
+  else {
+    digitalWrite(LED_Yellow, LOW);
+  }
+
   flashingLedState++;
 
 }


### PR DESCRIPTION
LED: move flight mode LED processing to LedStatusProcessor.h
FlightCommand: separate altitude and position hold (<1600 = poshold, 1600-1750 = althold, >1750 no hold)

Note you can still use 2way switch, just set the endpoints per your wish.
