### PR TITLE
Fixed #ifdef issue, other RX types work again.

### DIFF
--- a/AeroQuad/AeroQuad.ino
+++ b/AeroQuad/AeroQuad.ino
@@ -1408,7 +1408,7 @@ void loop () {
       G_Dt = (currentTime - fiftyHZpreviousTime) / 1000000.0;
       fiftyHZpreviousTime = currentTime;
 
-      #ifdef ReceiverSBUS
+      #if defined ReceiverSBUS
         readSBUS();
       #endif
       


### PR DESCRIPTION
I tested this, sBUS still works and also normal PWM measurement worked
as well. Not sure why it didn't like #ifdef.
