### PR TITLE
Some bug fixing and clean-up

### DIFF
--- a/AeroQuad/MavLink.h
+++ b/AeroQuad/MavLink.h
@@ -204,7 +204,7 @@ void evaluateCopterType() {
 	systemType = MAV_TYPE_TRICOPTER;
   #endif
 
-  #if defined(quadXConfig) || defined(quadPlusConfig) || defined(quadXHT_FPVConfig) || defined(quadY4Config)
+  #if defined(quadXConfig) || defined(quadPlusConfig) || defined(quadY4Config)
 	systemType = MAV_TYPE_QUADROTOR;
   #endif
 

--- a/AeroQuad/SerialCom.h
+++ b/AeroQuad/SerialCom.h
@@ -89,7 +89,7 @@ void readSerialCommand() {
     case 'C': // Receive yaw PID
       readSerialPID(ZAXIS_PID_IDX);
       readSerialPID(HEADING_HOLD_PID_IDX);
-      readFloatSerial();
+      headingHoldConfig = readFloatSerial();
       break;
 
     case 'D': // Altitude hold PID
@@ -421,6 +421,7 @@ void sendSerialTelemetry() {
     for (byte axis = XAXIS; axis < LASTCHANNEL; axis++) {
       PrintValueComma(receiverSmoothFactor[axis]);
     }
+	PrintDummyValues(10 - LASTCHANNEL);
     SERIAL_PRINTLN();
     queryType = 'X';
     break;
@@ -883,9 +884,8 @@ void reportVehicleState() {
     SERIAL_PRINTLN("Octo X8");
   #elif defined(octoXConfig)
     SERIAL_PRINTLN("Octo X");
-  // *** For next rev, updat OctoPlus config name here and in Configurator
   #elif defined(octoPlusConfig)
-    SERIAL_PRINTLN("Octo X+");
+    SERIAL_PRINTLN("Octo +");
   #endif
 
   SERIAL_PRINT("Receiver Channels: ");

--- a/AeroQuad/UserConfiguration.h
+++ b/AeroQuad/UserConfiguration.h
@@ -57,7 +57,6 @@
 //For more information please refer to http://aeroquad.com/showwiki.php?title=Flight+Configurations
 
 #define quadXConfig
-//#define quadXHT_FPVConfig
 //#define quadPlusConfig
 //#define hexPlusConfig
 //#define hexXConfig      


### PR DESCRIPTION
- Fixed a bug which didn't allow you to update transmitter smoothing values via Configurator when LASTCHANNEL = 6 or 8, as Configurator expects 10 values but only 6 or 8 are sent
- Fixed bug which didn't allow you to set headingHoldConfig
- Fixed wrong name of Octo + Configuration
- Removed unused parts about quadXHT_FPVConfig
