### PR TITLE
remove _ in UseGPS as in GpsAdapter.h

### DIFF
--- a/AeroQuad/AeroQuad.ino
+++ b/AeroQuad/AeroQuad.ino
@@ -32,7 +32,7 @@
 // Define Security Checks
 //
 
-#if defined(UseGPS_NMEA) || defined(UseGPS_UBLOX) || defined(UseGPS_MTK) || defined(UseGPS_406)
+#if defined(UseGPSNMEA) || defined(UseGPSUBLOX) || defined(UseGPSMTK) || defined(UseGPS406)
  #define UseGPS
 #endif 
 


### PR DESCRIPTION
GpsAdapter.h UseGps\* don't have underscore, as in AeroQuad.ino. Is it the right solution? Or add underscores in GpsAdapter.h?
