### PR TITLE
Mod function not displaying 180 degrees for some reason 

### DIFF
--- a/Libraries/AQ_OSD/MAX7456_Heading.h
+++ b/Libraries/AQ_OSD/MAX7456_Heading.h
@@ -28,7 +28,12 @@
 int lastHeading = 361; // bogus to force update
 
 void displayHeading(float currentHeading) {
-  int currentHeadingDeg = ((int)(currentHeading / M_PI * 180.0) + 360) % 360;
+  int currentHeadingDeg = ((int)(currentHeading * 180/M_PI));
+
+  if (currentHeadingDeg < 0 ){ 
+   currentHeadingDeg = map(currentHeadingDeg, -179, -1,  180, 359); 
+  }
+
   if (currentHeadingDeg != lastHeading) {
     char buf[6];
     snprintf(buf,6,"\026%3d\027",currentHeadingDeg); // \026 is compass \027 is degree symbol


### PR DESCRIPTION
Mod function not displaying 180 degrees for some reason, temporary workaround until better option presents itself
