### PR TITLE
1234 is valid value on aq32 (12bit dac)

### DIFF
--- a/Libraries/AQ_OSD/MAX7456_RSSI.h
+++ b/Libraries/AQ_OSD/MAX7456_RSSI.h
@@ -33,9 +33,9 @@
   #include <AnalogRSSIReader.h>
 #endif	
 
-short lastRSSI = 1234; //forces update at first run
+short lastRSSI = 4321; //forces update at first run
 #if defined (UseEzUHFRSSIReader)
-  short lastQuality = 1234;  //forces update at first run
+  short lastQuality = 4321;  //forces update at first run
 #endif
 
 void displayRSSI() {


### PR DESCRIPTION
because AQ32 has a 12bit DAC, 0-4095 are valid values. Replaced 1234 with 4321.
