### PR TITLE
users of aq32 can't choice between 300Hz or 400Hz ESCs

### DIFF
--- a/Libraries/AQ_Motors/Motors_STM32.h
+++ b/Libraries/AQ_Motors/Motors_STM32.h
@@ -8,7 +8,11 @@
 ////////////////////////////////////////////////////////
 // definition section
 
-#define PWM_FREQUENCY   400      // Hz
+#if defined (USE_400HZ_ESC)
+  #define PWM_FREQUENCY 400   // in Hz
+#else
+  #define PWM_FREQUENCY 300   // in Hz
+#endif
 #define PWM_PERIODE     (1000000/PWM_FREQUENCY)
 
 #ifdef MOTORS_STM32_TRI


### PR DESCRIPTION
implemented as in Motors_PWM_Timer.h
