### PR TITLE
BatteryMonitor: add casts to make new compiler versions happy

### DIFF
--- a/Libraries/AQ_BatteryMonitor/BatteryMonitorTypes.h
+++ b/Libraries/AQ_BatteryMonitor/BatteryMonitorTypes.h
@@ -49,9 +49,9 @@ extern boolean            batteryWarning;    // any battery in warning state
 
 // Helper macros to make battery definitions cleaner
 #ifdef BM_EXTENDED
-#define DEFINE_BATTERY(CELLS,VPIN,VSCALE,VBIAS,CPIN,CSCALE,CBIAS) {(VPIN),(CELLS),(VSCALE)*100.0,(VBIAS)*100.0,0,0,(CPIN),(CSCALE)*10.0,(CBIAS)*10.0,0,0,0}
+#define DEFINE_BATTERY(CELLS,VPIN,VSCALE,VBIAS,CPIN,CSCALE,CBIAS) {(VPIN),(CELLS),(short)((VSCALE)*100.0),(short)((VBIAS)*100.0),0,0,(CPIN),(short)((CSCALE)*10.0),(short)((CBIAS)*10.0),0,0,0}
 #else
-#define DEFINE_BATTERY(CELLS,VPIN,VSCALE,VBIAS,CPIN,CSCALE,CBIAS) {(VPIN),(CELLS),(VSCALE)*100.0,(VBIAS)*100.0,0}
+#define DEFINE_BATTERY(CELLS,VPIN,VSCALE,VBIAS,CPIN,CSCALE,CBIAS) {(VPIN),(CELLS),(short)((VSCALE)*100.0),(short)((VBIAS)*100.0),0}
 #endif
 
 // Function declarations


### PR DESCRIPTION
This will just remove the warnings below

<pre>
/home/khautio/src/AeroQuad/AeroQuad32/../AeroQuad/AeroQuad.ino:1019:55: warning: narrowing conversion of '2.53e+3f' from 'float' to 'short int' inside { } is ill-formed in C++11 [-Wnarrowing]
/home/khautio/src/AeroQuad/AeroQuad32/../AeroQuad/AeroQuad.ino:1019:55: warning: narrowing conversion of '0.0f' from 'float' to 'short int' inside { } is ill-formed in C++11 [-Wnarrowing]
/home/khautio/src/AeroQuad/AeroQuad32/../AeroQuad/AeroQuad.ino:1019:55: warning: narrowing conversion of '0.0f' from 'float' to 'short int' inside { } is ill-formed in C++11 [-Wnarrowing]
/home/khautio/src/AeroQuad/AeroQuad32/../AeroQuad/AeroQuad.ino:1019:55: warning: narrowing conversion of '0.0f' from 'float' to 'short int' inside { } is ill-formed in C++11 [-Wnarrowing]
</pre>
