### PR TITLE
Re-Initialize altitude when "Reset Home" from OSD Menu

### DIFF
--- a/AeroQuad/OSDMenu.h
+++ b/AeroQuad/OSDMenu.h
@@ -98,6 +98,9 @@ void menuHandleSimple(byte mode, byte action) {
     case 2:
       homePosition.latitude   = GPS_INVALID_ANGLE;
       homePosition.longitude  = GPS_INVALID_ANGLE;
+#if defined AltitudeHoldBaro
+      initializeBaro();
+#endif
       break;
 #endif
 /* TEMPLATE CODE FOR NEW ACTION:


### PR DESCRIPTION
Reset altitude to zero ft/m using initializeBaro(); function when "Reset Home" from OSD Config Menu is selected.
