### PR TITLE
Heading Hold feature

### DIFF
--- a/AeroQuad/HeadingHoldProcessor.h
+++ b/AeroQuad/HeadingHoldProcessor.h
@@ -38,7 +38,7 @@ void processHeading()
 {
   if (headingHoldConfig == ON) {
 
-    #if defined(HeadingMagHold)
+    #if defined(HeadingMagHold) && !defined(useGyroForHeadingHold)
       heading = degrees(trueNorthHeading);
     #else
       heading = degrees(gyroHeading);

--- a/AeroQuad/UserConfiguration.h
+++ b/AeroQuad/UserConfiguration.h
@@ -82,6 +82,7 @@
 // Please refer to http://aeroquad.com/showwiki.php?title=Using+the+transmitters+sticks+and+switches+to+operate+your+AeroQuad
 // *******************************************************************************************************************************
 //#define HeadingMagHold				// Enables Magnetometer, gets automatically selected if CHR6DM is defined
+//#define useGyroForHeadingHold                         // Uses gyro only for heading hold but still samples mag for true heading display on OSD, etc.
 //#define AltitudeHoldBaro			// Enables Barometer
 //#define AltitudeHoldRangeFinder	// Enables Altitude Hold with range finder, not displayed on the configurator (yet)
 //#define AutoLanding				// Enables auto landing on channel AUX3 of the remote, NEEDS AltitudeHoldBaro AND AltitudeHoldRangeFinder to be defined


### PR DESCRIPTION
Enables mag for true heading display in OSD, etc. but still uses gyro
only for heading hold.
