### PR TITLE
Development v4 fix autolanding vs autodescent

### DIFF
--- a/AeroQuad/FlightControlProcessor.h
+++ b/AeroQuad/FlightControlProcessor.h
@@ -219,7 +219,7 @@ void processThrottleCorrection() {
   #endif
   #if defined (AutoLanding)
     #if defined BattMonitorAutoDescent
-      if (batteyMonitorThrottleCorrection != 0) { // don't auto land in the same time that the battery monitor do auto descent, or Override the auto descent to land, TBD
+      if (batteryMonitorAlarmCounter < BATTERY_MONITOR_MAX_ALARM_COUNT) { // don't auto land in the same time that the battery monitor do auto descent, or Override the auto descent to land, TBD
         throttleAdjust += autoLandingThrottleCorrection;
       }
     #else


### PR DESCRIPTION
the comments say "don't auto land in the same time that the battery monitor do auto descent.." but the "if" statement is only true when batteyMonitorThrottleCorrection is not zero
