### PR TITLE
fix compilation for aq32 with codesourcery's gcc version 2013.11.24

### DIFF
--- a/Libmaple/libmaple/libmaple/usbF4/VCP/usbd_cdc_vcp.c
+++ b/Libmaple/libmaple/libmaple/usbF4/VCP/usbd_cdc_vcp.c
@@ -255,7 +255,6 @@ typedef struct {
 
 void systemHardReset(void) {
     SCB_TypeDef* rSCB = (SCB_TypeDef *) SCB_BASE;
-    typedef void (*funcPtr)(void);
 
     /* Reset */
     rSCB->AIRCR = (u32)AIRCR_RESET_REQ;


### PR DESCRIPTION
Compiling with codesourcery's gcc version 2013.11.24 fail for an unused pointer. The error:

```
/home/rgorosito/git/AeroQuad/Libmaple/libmaple/libmaple/usbF4/VCP/usbd_cdc_vcp.c: In function 'systemHardReset':
/home/rgorosito/git/AeroQuad/Libmaple/libmaple/libmaple/usbF4/VCP/usbd_cdc_vcp.c:258:20: error: typedef 'funcPtr' locally defined but not used [-Werror=unused-local-typedefs]
     typedef void (*funcPtr)(void);
                    ^
cc1: all warnings being treated as errors
make: *** [build/./libmaple/usbF4/VCP/usbd_cdc_vcp.o] Error 1
```

the fix only remove this unused declaration
